### PR TITLE
useformSubscription hook

### DIFF
--- a/src/lib/FormSubscriber.tsx
+++ b/src/lib/FormSubscriber.tsx
@@ -1,9 +1,9 @@
 import { FormState, DefaultFormValues } from "./types";
 import invariant from "invariant";
-import { useForm } from "./useForm";
-import { useSelector, shallowEqual } from "react-redux";
 import { useEffect, useRef } from "react";
 import { FormToolkit } from "./FormToolkit";
+import { useForm } from "./useForm";
+import { useFormSubscription } from "./useFormSubscription";
 
 export interface FormSubscriberProps<V extends DefaultFormValues, T> {
   subscription: (state: FormState<V>) => T;
@@ -12,24 +12,22 @@ export interface FormSubscriberProps<V extends DefaultFormValues, T> {
   children?: (subscriptonResult: T, toolkit: FormToolkit<V>) => React.ReactNode;
 }
 
-export const FormSubscriber: <V extends DefaultFormValues, T>(
-  props: FormSubscriberProps<V, T>
-) => React.ReactElement<any, any> | null = ({
+export const FormSubscriber = <V extends DefaultFormValues, T>({
   subscription,
   onMount,
   onChange,
   children,
-}) => {
+}: FormSubscriberProps<V, T>) => {
   invariant(
     onMount ?? onChange ?? children,
     "FormSubscriber - Must include one of [onMount, onChange, children] props"
   );
+  const formToolkit = useForm<V>();
 
-  const formToolkit = useForm<any>();
-
-  const subscriptonResult = useSelector(() => {
-    return subscription(formToolkit.getState());
-  }, shallowEqual);
+  const subscriptonResult = useFormSubscription<V, T>(
+    formToolkit,
+    subscription
+  );
 
   const mountedRef = useRef(false);
   const refs = useRef({ onChange, onMount });

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -4,6 +4,7 @@ export { FormProvider } from "./FormProvider";
 export { FormMighty } from "./FormMighty";
 export { FormSubscriber } from "./FormSubscriber";
 export { useInitForm } from "./useInitForm";
+export { useFormSubscription } from "./useFormSubscription";
 export type { FormState, FormToolkitOptions } from "./types";
 
 enablePatches();

--- a/src/lib/useFormSubscription.ts
+++ b/src/lib/useFormSubscription.ts
@@ -1,0 +1,31 @@
+import invariant from "invariant";
+import { shallowEqual, useSelector } from "react-redux";
+import { FormToolkit } from "./FormToolkit";
+import { DefaultFormValues, FormState } from "./types";
+import { useForm } from "./useForm";
+
+export const useFormSubscription = <
+  V extends DefaultFormValues,
+  T = FormState<V>
+>(
+  ...args:
+    | []
+    | [FormToolkit<V>?, ((state: FormState<V>) => T)?]
+    | [(state: FormState<V>) => T]
+) => {
+  const contextTk = useForm<V>();
+
+  const tk = args[0] instanceof FormToolkit ? args[0] : undefined;
+  const subscriptionFn =
+    (args[0] instanceof FormToolkit ? args[1] : args[0]) ?? ((state) => state);
+
+  invariant(
+    contextTk || tk,
+    "useFormSubscription - Either use inside FormMighty scope or pass toolkit as the first argument"
+  );
+
+  return useSelector(
+    () => subscriptionFn((tk ?? contextTk).getState()),
+    shallowEqual
+  );
+};

--- a/src/lib/useFormSubscription.ts
+++ b/src/lib/useFormSubscription.ts
@@ -27,5 +27,5 @@ export const useFormSubscription = <
   return useSelector(
     () => subscriptionFn((tk ?? contextTk).getState()),
     shallowEqual
-  );
+  ) as T;
 };

--- a/src/lib/useFormSubscription.ts
+++ b/src/lib/useFormSubscription.ts
@@ -12,7 +12,7 @@ export const useFormSubscription = <
     | []
     | [FormToolkit<V>?, ((state: FormState<V>) => T)?]
     | [(state: FormState<V>) => T]
-) => {
+): T => {
   const contextTk = useForm<V>();
 
   const tk = args[0] instanceof FormToolkit ? args[0] : undefined;

--- a/src/tests/useFormSubscription.test.tsx
+++ b/src/tests/useFormSubscription.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from "@testing-library/react-hooks";
-import { FormMighty, FormProvider } from "src/lib";
+import { FormMighty, FormProvider, FormState } from "src/lib";
 import { FormToolkit } from "src/lib/FormToolkit";
 import { useFormSubscription } from "src/lib/useFormSubscription";
 
@@ -86,7 +86,8 @@ it("should return a form state using a given subscriptionFn", async () => {
 });
 
 it("should accept subscriptionFn as first argument and use context's toolkit", async () => {
-  const tk = new FormToolkit({
+  type MyForm = { value: number };
+  const tk = new FormToolkit<MyForm>({
     initialValues: { value: 1 },
   });
 
@@ -99,7 +100,7 @@ it("should accept subscriptionFn as first argument and use context's toolkit", a
   };
 
   const { result } = renderHook(
-    () => useFormSubscription((state) => state.values.value),
+    () => useFormSubscription((state: FormState<MyForm>) => state.values.value),
     {
       wrapper: Wrapper,
     }

--- a/src/tests/useFormSubscription.test.tsx
+++ b/src/tests/useFormSubscription.test.tsx
@@ -1,0 +1,132 @@
+import { renderHook } from "@testing-library/react-hooks";
+import { FormMighty, FormProvider } from "src/lib";
+import { FormToolkit } from "src/lib/FormToolkit";
+import { useFormSubscription } from "src/lib/useFormSubscription";
+
+it("should work", () => {
+  const Wrapper: React.FC = ({ children }) => {
+    return <FormProvider>{children}</FormProvider>;
+  };
+
+  const { result } = renderHook(() => useFormSubscription(new FormToolkit()), {
+    wrapper: Wrapper,
+  });
+
+  expect(result.error).not.toBeDefined();
+});
+
+it("should return the entire form state if passing a toolkit instance", () => {
+  const Wrapper: React.FC = ({ children }) => {
+    return <FormProvider>{children}</FormProvider>;
+  };
+
+  const tk = new FormToolkit();
+  const { result } = renderHook(() => useFormSubscription(tk), {
+    wrapper: Wrapper,
+  });
+
+  expect(result.current).toBe(tk.getState());
+});
+
+it("should use the toolkit from context if not passed", () => {
+  const tk = new FormToolkit({ initialValues: { value: 5 } });
+
+  const Wrapper: React.FC = ({ children }) => {
+    return (
+      <FormProvider>
+        <FormMighty toolkit={tk}>{children}</FormMighty>
+      </FormProvider>
+    );
+  };
+
+  const { result } = renderHook(() => useFormSubscription(), {
+    wrapper: Wrapper,
+  });
+
+  expect(result.current).toBe(tk.getState());
+});
+
+it("should return a reactive form state", async () => {
+  const tk = new FormToolkit({
+    initialValues: { value: 1 },
+  });
+
+  const Wrapper: React.FC = ({ children }) => {
+    return <FormProvider>{children}</FormProvider>;
+  };
+
+  const { result } = renderHook(() => useFormSubscription(tk), {
+    wrapper: Wrapper,
+  });
+
+  tk.updateValues((draft) => {
+    draft.value = 2;
+  });
+
+  expect(result.current).toBe(tk.getState());
+});
+
+it("should return a form state using a given subscriptionFn", async () => {
+  const tk = new FormToolkit({
+    initialValues: { value: 1 },
+  });
+
+  const Wrapper: React.FC = ({ children }) => {
+    return <FormProvider>{children}</FormProvider>;
+  };
+
+  const { result } = renderHook(
+    () => useFormSubscription(tk, (state) => state.values.value),
+    {
+      wrapper: Wrapper,
+    }
+  );
+
+  expect(result.current).toBe(tk.getState().values.value);
+});
+
+it("should accept subscriptionFn as first argument and use context's toolkit", async () => {
+  const tk = new FormToolkit({
+    initialValues: { value: 1 },
+  });
+
+  const Wrapper: React.FC = ({ children }) => {
+    return (
+      <FormProvider>
+        <FormMighty toolkit={tk}>{children}</FormMighty>
+      </FormProvider>
+    );
+  };
+
+  const { result } = renderHook(
+    () => useFormSubscription((state) => state.values.value),
+    {
+      wrapper: Wrapper,
+    }
+  );
+
+  expect(result.current).toBe(tk.getState().values.value);
+});
+
+it("should not trigger render if result equals shallowly", async () => {
+  const tk = new FormToolkit({
+    initialValues: { value: 1 },
+  });
+
+  const Wrapper: React.FC = ({ children }) => {
+    return <FormProvider>{children}</FormProvider>;
+  };
+
+  const { result } = renderHook(
+    () => useFormSubscription(tk, (state) => ({ ...state.initialValues })),
+    {
+      wrapper: Wrapper,
+    }
+  );
+
+  tk.updateValues((draft) => {
+    draft.value = 2;
+  });
+
+  expect(result.all.length).toBe(1);
+});


### PR DESCRIPTION
Brief description of the hook

* By default returns a reactive state of the form. A subscriptionFn may also be passed and a reactive subset of the state will be returned(Recommended for better performance ;) ).
* By default it will use the context to get the FormToolkit. A toolkit object may be passed as well.